### PR TITLE
FIX - When user changes resolution in EE.

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -86,8 +86,7 @@ BASEROMNAME=${ROMNAME##*/}
 GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
 
 [[ -f "/emuelec/bin/setres.sh" ]] && SET_DISPLAY_SH="/emuelec/bin/setres.sh" || SET_DISPLAY_SH="/usr/bin/setres.sh"
-VIDEO=$(get_ee_setting global.videomode)
-[[ -z "$VIDEO" ]] && VIDEO=$(get_ee_setting ee_videomode)
+VIDEO=`cat /sys/class/display/mode`;
 VIDEO_EMU=$(get_ee_setting nativevideo "${PLATFORM}" "${BASEROMNAME}")
 
 if [[ "${CORE}" == *"_32b"* ]]; then


### PR DESCRIPTION
When the User changes resolution in EE, it's not applied till EE is restarted. Currently it's possible to set the EE resolution and not have it apply and when launching a native resolution it retrieves the new Resolution when going back when quitting the game and going back to EE causing video corruption.
This makes sure it reverts to the current display and not the future display. If a user wants to say select 720p in EE, but it's currently 1080p they have to restart EE, and switching to and back from Native resolution will work properly.