### PR TITLE
Dev port nativevideo - Allows ports to use native video option from ES

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -1483,7 +1483,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<hardware>port</hardware>
 		<path>/storage/roms/ports_scripts</path>
 		<extension>.sh .SH</extension>
-		<command>/usr/bin/bash %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
+		<command>emuelecRunApp.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>ports</platform>
 		<theme>ports</theme>
 		<emulators>

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -371,6 +371,8 @@ function init_app_video() {
 
 	blank_buffer
 
+	[[ -f "/tmp/EE_LASTVIDEO" ]] && return
+
 	echo "$(cat /sys/class/display/mode)" > /tmp/EE_LASTVIDEO
 	local VIDEO_EMU=$(get_ee_setting nativevideo "${PLATFORM}" "${BASEROMNAME}")
 	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$LAST_VIDEO
@@ -386,11 +388,15 @@ function init_app_video() {
 function end_app_video() {
 	local LAST_VIDEO="$(cat /tmp/EE_LASTVIDEO)"
 
+	[[ ! -f "/tmp/EE_LASTVIDEO" ]] && return
+
 	# Return to default mode
 	${TBASH} setres.sh ${LAST_VIDEO}
 
 	# Show exit splash
 	${TBASH} show_splash.sh exit
+
+	rm /tmp/EE_LASTVIDEO
 }
 
 function set_gptokeyb() {

--- a/packages/sx05re/emuelec/bin/emuelecRunApp.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunApp.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
+# Copyright (C) 2024-present Langerz82 (https://github.com/Langerz82)
+
+# Source predefined functions and variables
+. /etc/profile
+
+arguments="$@"
+
+# Extract the platform name from the arguments
+PLATFORM="${arguments##*-P}"  # read from -P onwards
+PLATFORM="${PLATFORM%% *}"  # until a space is found
+
+ROMNAME="${1}"
+BASEROMNAME=${ROMNAME##*/}
+GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
+
+emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
+
+RUN_CMD="$1"
+shift
+
+"$RUN_CMD" "$@"
+
+emuelec-utils end_app_video

--- a/packages/sx05re/emuelec/bin/emuelecRunApp.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunApp.sh
@@ -19,9 +19,6 @@ GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
 
 emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 
-RUN_CMD="$1"
-shift
-
-"$RUN_CMD" "$@"
+"$@"
 
 emuelec-utils end_app_video

--- a/packages/sx05re/emuelec/bin/emuelecRunApp.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunApp.sh
@@ -14,8 +14,6 @@ PLATFORM="${arguments##*-P}"  # read from -P onwards
 PLATFORM="${PLATFORM%% *}"  # until a space is found
 
 ROMNAME="${1}"
-BASEROMNAME=${ROMNAME##*/}
-GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
 
 emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 


### PR DESCRIPTION
Dev port nativevideo - Allows ports to use native video option from ES.

I found the easiest way is to create a seperate file that ports can run through in order to be able to get native video functionality working for ports.

**My reasoning seperating into a new file is this:**
1. Some ports call emuelecRunEmu, and if they do they will needed to additionally coded to handle everything being called twice.
2. Having a seperate file, in addition with nativevideo conditionals in emuelec-utils ensures that video switching occurs only once and if called again in emuelecRunEmu it will be ignored.
3. This simplifies the code without having to edit a monolithic file e.g. emuelecRunEmu.sh.
4. runApp could also be used in future for for needed functions that are common to everything es opens, for example maybe gptokeyb etc, ES window error handling etc.
5. Should be compatible with PortMaster Ports with no additional code needed.
 